### PR TITLE
fix: bash-completion now also completes the `help` command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ on:
       - '.npmignore'
       - 'LICENSE'
       - 'README.md'
-      - 'bash-completion.sh'
   push:
     paths-ignore:
       - '.devcontainer/**'
@@ -28,7 +27,6 @@ on:
       - '.npmignore'
       - 'LICENSE'
       - 'README.md'
-      - 'bash-completion.sh'
 
 permissions:
   contents: read # to fetch code (actions/checkout)

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ NodeJS CLI which simplifies the headless setup of a Raspberry Pi
 Install it locally with
 
 ```bash
-npm i https://github.com/matteosacchetto/rpi-headless-setup-helper/releases/download/v0.2.0/matteosacchetto-rpi-headless-setup-helper-0.2.0.tgz
+npm i https://github.com/matteosacchetto/rpi-headless-setup-helper/releases/download/v0.2.1/matteosacchetto-rpi-headless-setup-helper-0.2.1.tgz
 ```
 
 Or install it globally with
 
 ```bash
-npm i --location=global https://github.com/matteosacchetto/rpi-headless-setup-helper/releases/download/v0.2.0/matteosacchetto-rpi-headless-setup-helper-0.2.0.tgz
+npm i --location=global https://github.com/matteosacchetto/rpi-headless-setup-helper/releases/download/v0.2.1/matteosacchetto-rpi-headless-setup-helper-0.2.1.tgz
 ```
 
 ### Other version
@@ -38,11 +38,11 @@ Or install it globally with
 npm i --location=global <link-to-rpi-headless-setup-helper-{version}.tgz>
 ```
 
-where you have to replace `{version}` with the version number you downloaded (ex: 0.2.0)
+where you have to replace `{version}` with the version number you downloaded (ex: 0.2.1)
 
 ### Bash completion
 
-Since version 0.2.0, the package also includes a bash completion script. If you install the package globally, you are on Linux and you use bash as your main shell, I highly suggest installing bash completion, as it improves the UX of this module.
+Since version 0.2.1, the package also includes a bash completion script. If you install the package globally, you are on Linux and you use bash as your main shell, I highly suggest installing bash completion, as it improves the UX of this module.
 
 To install it, I recommend to perform the following steps.
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ where you have to replace `{version}` with the version number you downloaded (ex
 
 ### Bash completion
 
-Since version 0.2.1, the package also includes a bash completion script. If you install the package globally, you are on Linux and you use bash as your main shell, I highly suggest installing bash completion, as it improves the UX of this module.
+Since version 0.2.0, the package also includes a bash completion script. If you install the package globally, you are on Linux and you use bash as your main shell, I highly suggest installing bash completion, as it improves the UX of this module.
 
 To install it, I recommend to perform the following steps.
 

--- a/bash-completion.sh
+++ b/bash-completion.sh
@@ -75,7 +75,7 @@ __rpi-headless-setup-helper_completion() {
       return 0;
     ;;
     *)
-      COMPREPLY=($(compgen -W "-h --help -v --version ssh user wifi" -- "$cur"))
+      COMPREPLY=($(compgen -W "-h --help -v --version ssh user wifi help" -- "$cur"))
       return 0;
     ;;
   esac


### PR DESCRIPTION
With this PR the following change is introduced
- bash-completion now also completes the `help` command

This PR also fixes the CI pipeline to include bash-completion within the CI triggering paths